### PR TITLE
fix: add parse in date transactions

### DIFF
--- a/src/controllers/TransactionsControllers.ts
+++ b/src/controllers/TransactionsControllers.ts
@@ -39,16 +39,22 @@ export default new class TransactionsController {
   async create (req: Request, resp: Response) {
     try {
       const transactionsRepository = getCustomRepository(TransactionsRepository)
-      const transaction = await transactionsRepository.save(req.body)
-        .catch(erro => {
+      const date_parse = parse(req.body.due_date, "dd/MM/yyyy", new Date())
+
+      const transaction = await transactionsRepository
+      .save({
+        ...req.body,
+        due_date: date_parse,
+      })
+      .catch(erro => {
           const { errno: errorForeignKeyCode } = erro
           return { message: errorForeignKeyCode }
-        })
+        })  
 
       if (transaction.message) {
         return resp.status(422).json({ message: 'category not found' })
-      }
-
+      }   
+ 
       return resp.status(201).json({ message: 'success', body: [transaction] })
     } catch (error) {
       console.error(error)


### PR DESCRIPTION
Datas acima do dia 12 não estava sendo gravadas no banco, a validação funciona porém faltou o parse das datas antes de inserir no banco de dados